### PR TITLE
fix/json-body-logging-truncation

### DIFF
--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -56,7 +56,9 @@ export const formatBody = (body: string | Buffer | Record<string, any>): string 
     return body.length > 1000 ? `<Buffer ${body.length} bytes>` : body.toString();
   }
 
-  return JSON.stringify(body, null, 2);
+  const json = JSON.stringify(body, null, 2);
+
+  return json?.length > 1500 ? `${json.slice(0, 1000)} ...` : json;
 };
 
 export const formatRouteResponse = (req: MoxyRequest, res: MoxyResponse): string => {


### PR DESCRIPTION
fix: json output logging was not truncated like body or buffer