### PR TITLE
fix/logging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,12 +49,12 @@ export const getOption = (config: CliConfig, argv?: string[]): number => {
       return 0;
     case '-h':
     case '--help':
-      process.stdout.write(usage);
+      console.log(usage.replace(/\n$/, ''));
       process.exit(0);
 
     case '-v':
     case '--version':
-      process.stdout.write(`${version}\n`);
+      console.log(version);
       process.exit(0);
 
     case '-r':
@@ -132,7 +132,7 @@ export const main = async (argv?: string[]): Promise<MoxyServer> => {
 
 if (require.main === module) {
   main(process.argv.slice(2)).catch((error: Error) => {
-    process.stderr.write((error as Error).message);
+    console.error(error);
     process.exit(1);
   });
 }


### PR DESCRIPTION
Error logs on CLI exit were sometimes not visible when writing to process stdout/stderr.

Since the node logger colours are fixed now, we can simply use console again.