### PR TITLE
feat/try-for-typescript-routes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,23 +3,11 @@ import { default as acrLint } from '@acrontum/eslint-config';
 
 export default [
   { ignores: ['test/fixtures', '**/node_modules', 'dist/'] },
-  {
-    files: ['**/*.spec.ts'],
-    rules: {
-      'max-lines-per-function': 'off',
-    },
-  },
   ...acrLint,
   {
     files: ['src/cli.ts', 'src/util/logger.ts'],
     rules: {
       'no-console': 'off',
-    },
-  },
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/restrict-template-expressions': ['error', { allowBoolean: true, allowNumber: true,  }],
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "moxy": "dist/src/cli.js"
       },
       "devDependencies": {
-        "@acrontum/eslint-config": "^1.2.1",
+        "@acrontum/eslint-config": "^2.0.1",
         "@tsconfig/node18": "^18.2.4",
         "@types/node": "^24.10.9",
         "@types/supertest": "^6.0.2",
@@ -32,24 +32,22 @@
       }
     },
     "node_modules/@acrontum/eslint-config": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@acrontum/eslint-config/-/eslint-config-1.2.3.tgz",
-      "integrity": "sha512-tUcjbM3XqkxlEkH1AJHLc2kE8VSDSE9+2aJZWtlm6ASSQJ2ECysQtqz+hRfFjKGDb77RYIaSfbGbBvsi8Bmudw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@acrontum/eslint-config/-/eslint-config-2.0.1.tgz",
+      "integrity": "sha512-IwYkdUL51XSFPW1wEZcCM0dfnvzVroaos/S02/iBWSKf6Xl+jZNAzi68RHoawLJSoqPSa2xSHCVOWCVxLL8VGQ==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "@eslint/eslintrc": ">= 3.1.0",
-        "@eslint/js": ">= 9.5.0",
-        "@typescript-eslint/eslint-plugin": ">= 7",
-        "@typescript-eslint/parser": ">= 7",
-        "eslint": ">= 7",
+        "angular-eslint": ">= 20",
+        "eslint": ">= 9",
         "eslint-config-prettier": ">= 7",
-        "eslint-plugin-no-only-tests": ">= 3",
         "eslint-plugin-prettier": ">= 5",
-        "prettier": ">= 3"
+        "globals": "^14.0.0",
+        "prettier": ">= 3",
+        "typescript-eslint": "^8"
       },
       "peerDependenciesMeta": {
-        "@eslint/eslintrc": {
+        "angular-eslint": {
           "optional": true
         }
       }
@@ -99,9 +97,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -110,9 +108,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -154,7 +152,6 @@
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -174,9 +171,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -195,9 +192,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -213,7 +210,6 @@
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -461,21 +457,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.1.tgz",
-      "integrity": "sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.53.1",
-        "@typescript-eslint/type-utils": "8.53.1",
-        "@typescript-eslint/utils": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -485,23 +480,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.53.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.67.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.1.tgz",
-      "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.53.1",
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -512,19 +506,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
-      "integrity": "sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -535,18 +529,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
-      "integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -557,9 +551,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.1.tgz",
-      "integrity": "sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -570,21 +564,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.1.tgz",
-      "integrity": "sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1",
-        "@typescript-eslint/utils": "8.53.1",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -594,14 +588,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
-      "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -613,21 +607,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.1.tgz",
-      "integrity": "sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.53.1",
-        "@typescript-eslint/tsconfig-utils": "8.53.1",
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -637,20 +631,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.1.tgz",
-      "integrity": "sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.53.1",
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -660,19 +693,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
-      "integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.67.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -683,13 +716,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -701,7 +734,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -720,9 +752,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -781,9 +813,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1079,7 +1111,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1140,7 +1171,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -1151,24 +1181,12 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-no-only-tests": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
-      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=5.0.0"
-      }
-    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
       "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
         "synckit": "^0.11.12"
@@ -1225,9 +1243,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1259,9 +1277,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1446,24 +1464,24 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1615,9 +1633,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1695,10 +1713,20 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1753,10 +1781,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -1793,15 +1831,25 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -1874,13 +1922,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2010,12 +2058,11 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2039,7 +2086,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2084,13 +2130,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2110,9 +2157,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2146,15 +2193,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2166,14 +2213,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2321,14 +2368,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2338,9 +2385,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2392,13 +2439,37 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uc.micro": {
@@ -2459,9 +2530,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/acrontum/moxy#readme",
   "devDependencies": {
-    "@acrontum/eslint-config": "^1.2.1",
+    "@acrontum/eslint-config": "^2.0.1",
     "@tsconfig/node18": "^18.2.4",
     "@types/node": "^24.10.9",
     "@types/supertest": "^6.0.2",

--- a/readme.md
+++ b/readme.md
@@ -157,8 +157,6 @@ services:
 
 ## Examples (see [the examples folder](./examples))
 
-**note** that examples are in TypeScript for clarity, but moxy is a javascript library so you will need to transpile if you want to use TypeScript.  
-
 
 ### Simple server
 
@@ -781,7 +779,17 @@ See [API](#api) for full usage.
 
 ### From files
 
-Moxy can load routing configs from the filesystem, searching recursively for `.js` or `.json` files matching `<anything>.routes.js(on)`. This allows you to organize routes into files, and put them in a routes folder (as shown in the [example-routing folder](./examples/example-routing/)).
+Moxy can load route configs from a folder, searching recursively for route files. Route files are files who's name matches:
+- `.routes.js`
+- `.routes.json`
+
+For moxy version 5+, and node version v22.18.0+ (or 22+ with `--experimental-strip-types`), routes files can also be module or typescript files:
+- `.routes.mjs`
+- `.routes.mts`
+- `.routes.ts`
+
+
+This allows you to organize routes into files, and put them in a routes folder (as shown in the [example-routing folder](./examples/example-routing/)).  
 
 ```typescript
 await moxy.addRoutesFromFolder('/path/to/routes/folder');

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -23,12 +23,7 @@ export type Method = 'connect' | 'delete' | 'get' | 'head' | 'options' | 'patch'
 /**
  * Manual request handler
  */
-export type RequestHandler = (
-  req: MoxyRequest,
-  res: MoxyResponse,
-  variables: HandlerVariables,
-  server: MoxyServer,
-) => unknown;
+export type RequestHandler = (req: MoxyRequest, res: MoxyResponse, variables: HandlerVariables, server: MoxyServer) => unknown;
 
 export interface PathSettings {
   /**
@@ -186,10 +181,19 @@ export class Router {
       this.routes[path] = { ...(compiledRoute as PathConfig) };
       delete compiledRoute.urlRegex;
     } else {
-      this.routes[path] = {
-        ...((this.routes[path] as PathConfig | undefined) || {}),
-        ...(compiledRoute as PathConfig),
-      };
+      if (typeof this.routes[path] === 'string' || typeof this.routes[path] === 'function') {
+        this.routes[path] = { get: this.routes[path], ...(compiledRoute as PathConfig) };
+      } else if (typeof this.routes[path] === 'undefined') {
+        this.routes[path] = compiledRoute;
+      } else {
+        this.routes[path] = { ...this.routes[path], ...(compiledRoute as PathConfig) };
+      }
+
+      const existing =
+        typeof this.routes[path] === 'string' || typeof this.routes[path] === 'function'
+          ? { get: this.routes[path] }
+          : this.routes[path];
+      this.routes[path] = { ...existing, ...(compiledRoute as PathConfig) };
       delete compiledRoute.urlRegex;
     }
 
@@ -349,10 +353,7 @@ export class Router {
    */
   async requestListener(req: MoxyRequest, res: MoxyResponse): Promise<unknown> {
     if (!req.url) {
-      return res.sendJson(
-        { message: 'Req parsing error', status: 500 },
-        { headers: { 'X-Moxy-Error': 'Req URL is undefined' } },
-      );
+      return res.sendJson({ message: 'Req parsing error', status: 500 }, { headers: { 'X-Moxy-Error': 'Req URL is undefined' } });
     }
     if (!req.path) {
       return res.sendJson(
@@ -500,8 +501,7 @@ export class Router {
     routeConfig: ParsedPathConfig | null,
   ): { methodConfig: MethodConfig | null; proxySettings: PathSettings | null } {
     const method = req.method?.toLowerCase() as Method;
-    const methodConfig =
-      (routeConfig as PathConfigWithOptions)[method] || (routeConfig as PathConfigWithOptions).all || null;
+    const methodConfig = (routeConfig as PathConfigWithOptions)[method] || (routeConfig as PathConfigWithOptions).all || null;
 
     let proxySettings: PathSettings | null = null;
 
@@ -523,11 +523,7 @@ export class Router {
    *
    * @return {Promise<null | void | MoxyResponse>}
    */
-  #parseConfigRoute(
-    res: MoxyResponse,
-    methodConfig: MethodSettings | null,
-    variables: HandlerVariables,
-  ): null | MoxyResponse {
+  #parseConfigRoute(res: MoxyResponse, methodConfig: MethodSettings | null, variables: HandlerVariables): null | MoxyResponse {
     const status = methodConfig?.status ?? 200;
     const headers = methodConfig?.headers;
 
@@ -588,10 +584,6 @@ export class Router {
    * @return {ParsedPathConfig}  The parsed path configuration
    */
   #compileRoute(fullPath: string, config: RouteConfig, options?: AddRouteOptions): ParsedPathConfig {
-    if (typeof config === 'boolean') {
-      return config;
-    }
-
     let parsed = config as PathConfigWithOptions;
     if (typeof config === 'string') {
       parsed = { get: config };
@@ -639,9 +631,7 @@ export class Router {
    * @return {MoxyResponse}
    */
   #sendApiRoutes(req: MoxyRequest, res: MoxyResponse): MoxyResponse {
-    return res.sendJson(
-      Object.keys(req.query.once === 'true' ? Object.fromEntries(this.onceRouterPaths) : this.routes),
-    );
+    return res.sendJson(Object.keys(req.query.once === 'true' ? Object.fromEntries(this.onceRouterPaths) : this.routes));
   }
 
   /**

--- a/src/server/moxy-server.ts
+++ b/src/server/moxy-server.ts
@@ -296,7 +296,7 @@ export class MoxyServer {
    * @return {boolean}
    */
   #isRouterFile(path: string): boolean {
-    return /\.routes\.js(on)?$/.test(path);
+    return /\.routes\.(mts|mjs|js|ts|json)$/.test(path);
   }
 
   /**

--- a/src/server/moxy-server.ts
+++ b/src/server/moxy-server.ts
@@ -1,13 +1,14 @@
 import * as fs from 'node:fs';
 import { createServer, IncomingMessage, Server, ServerOptions, ServerResponse } from 'node:http';
 import { AddressInfo, Socket } from 'node:net';
-import { basename, join } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { AddRouteOptions, RouteConfig, Router, RouterConfig, Routes } from '../router/router';
 import { getId } from '../util/format';
 import { HttpException } from '../util/http-exception';
 import { Logger, LogLevel } from '../util/logger';
 import { MoxyRequest } from './request';
 import { MoxyResponse } from './response';
+import { access } from 'node:fs/promises';
 
 export interface ServerConfig {
   /**
@@ -196,17 +197,20 @@ export class MoxyServer {
   async loadConfigFromFile(filePath: string, basePath: string): Promise<void> {
     let pathConfig: Record<string, Routes>;
 
+    const fullPath = resolve(filePath);
+    await access(fullPath);
+
     try {
       /* eslint-disable-next-line @typescript-eslint/no-require-imports */
-      pathConfig = require(filePath) as Record<string, Routes>;
+      pathConfig = require(fullPath) as Record<string, Routes>;
     } catch (_requireError) {
       try {
-        pathConfig = (await import(filePath)) as Record<string, Routes>;
+        pathConfig = (await import(fullPath)) as Record<string, Routes>;
       } catch (_importError) {
         return;
       }
     }
-    const prefix = filePath.replace(`/${basename(filePath)}`, '').replace(basePath, '');
+    const prefix = fullPath.replace(`/${basename(filePath)}`, '').replace(resolve(basePath), '');
 
     if (filePath.endsWith('.json')) {
       pathConfig = { export: pathConfig };

--- a/src/server/moxy-server.ts
+++ b/src/server/moxy-server.ts
@@ -161,7 +161,7 @@ export class MoxyServer {
       }
 
       if (this.#isRouterFile(next.name)) {
-        this.loadConfigFromFile(next.name, path);
+        await this.loadConfigFromFile(next.name, path);
       }
     }
 
@@ -193,9 +193,19 @@ export class MoxyServer {
    * @param {string}  filePath  The file path
    * @param {string}  basePath  The base path
    */
-  loadConfigFromFile(filePath: string, basePath: string): void {
-    /* eslint-disable-next-line @typescript-eslint/no-require-imports */
-    let pathConfig = require(filePath) as Record<string, Routes>;
+  async loadConfigFromFile(filePath: string, basePath: string): Promise<void> {
+    let pathConfig: Record<string, Routes>;
+
+    try {
+      /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+      pathConfig = require(filePath) as Record<string, Routes>;
+    } catch (_requireError) {
+      try {
+        pathConfig = (await import(filePath)) as Record<string, Routes>;
+      } catch (_importError) {
+        return;
+      }
+    }
     const prefix = filePath.replace(`/${basename(filePath)}`, '').replace(basePath, '');
 
     if (filePath.endsWith('.json')) {
@@ -247,7 +257,7 @@ export class MoxyServer {
 
     this.#createConnectionManager();
 
-    return new Promise<MoxyHttpServer>((resolve, reject) => {
+    return await new Promise<MoxyHttpServer>((resolve, reject) => {
       server.on('error', reject);
 
       server.listen(port, () => {

--- a/src/server/request.ts
+++ b/src/server/request.ts
@@ -78,7 +78,7 @@ export class MoxyRequest extends IncomingMessage {
     const payload = await this.body;
 
     if (format === 'string') {
-      return (payload.toString('utf8') as string | null) ?? '';
+      return payload.toString('utf8');
     }
 
     if (format === 'json') {

--- a/src/server/response.ts
+++ b/src/server/response.ts
@@ -118,10 +118,7 @@ export class MoxyResponse extends ServerResponse<MoxyRequest> {
    * @param {Record<string, string | readonly string[] | number>}  headers  The headers
    */
   setHeaders(
-    headers:
-      | Headers
-      | Map<string, number | string | readonly string[]>
-      | Record<string, string | readonly string[] | number>,
+    headers: Headers | Map<string, number | string | readonly string[]> | Record<string, string | readonly string[] | number>,
   ): this {
     for (const [name, value] of Object.entries(headers) as [string, number | string | readonly string[]][]) {
       this.setHeader(name, value);

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { join, relative } from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, before, describe, it } from 'node:test';
 import { formatRoutesForPrinting, main, MoxyServer, RouteConfig } from '../src';
 import { getRequest, TestRequest } from './shared/test-util';
 
@@ -13,6 +13,15 @@ describe(relative(process.cwd(), __filename), async () => {
     await assertions(moxy);
     await moxy.close({ closeConnections: true });
   };
+
+  let supportsTs = false;
+  before(() => {
+    try {
+      /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+      require(join(process.cwd(), 'test/fixtures/ts-support.ts'));
+      supportsTs = true;
+    } catch (_e) {}
+  });
 
   afterEach(async () => {
     await moxy.close({ closeConnections: true });
@@ -63,8 +72,7 @@ describe(relative(process.cwd(), __filename), async () => {
 
   await it('can load routes from folder', async () => {
     const routes = join(__dirname, 'fixtures', 'load-from-dir');
-    const serializedDeleteFuntion =
-      "delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }";
+    const serializedDeleteFuntion = "delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }";
 
     await start(['-q', '-r', routes], (server) => {
       const routerConfig = JSON.parse(formatRoutesForPrinting(server.router.routes)) as unknown;
@@ -233,50 +241,63 @@ describe(relative(process.cwd(), __filename), async () => {
 
   await it('can load ts routes from folder', async () => {
     const routes = join(__dirname, '../../test/fixtures/load-from-dir');
-    const serializedDeleteFuntion =
-      "delete(req     , res     ) {\n      return res.writeHead(301, 'google.ca');\n    }";
+    const serializedDeleteFuntion = "delete(req     , res     ) {\n      return res.writeHead(301, 'google.ca');\n    }";
 
     await start(['-q', '-r', routes], (server) => {
       const routerConfig = JSON.parse(formatRoutesForPrinting(server.router.routes)) as unknown;
 
-      assert.deepStrictEqual(routerConfig, {
-        '/a/test': { get: { status: 200 } },
-        '/a/users/something': { delete: serializedDeleteFuntion },
-        '/a/y/test': { get: { status: 200 } },
-        '/a/y/users/something': { delete: serializedDeleteFuntion },
-        '/a/y/z/test': { get: { status: 200 } },
-        '/a/y/z/users/something': { delete: serializedDeleteFuntion },
-        '/b/json-b-test': {
-          get: {
-            status: 200,
-          },
-        },
-        '/b/json-b-test/users/something': {
-          delete: {
-            body: '<!DOCTYPE html><html><head><title>Nope</title></head><body><h1>405 Method not allowed</h1></body><html>',
-            headers: {
-              'Content-Type': 'text/html',
+      if (!supportsTs) {
+        assert.deepStrictEqual(routerConfig, {
+          '/b/json-b-test': { get: { status: 200 } },
+          '/b/json-b-test/users/something': {
+            delete: {
+              status: 405,
+              body: '<!DOCTYPE html><html><head><title>Nope</title></head><body><h1>405 Method not allowed</h1></body><html>',
+              headers: { 'Content-Type': 'text/html' },
             },
-            status: 405,
           },
-        },
-        '/b/test': { get: { status: 200 } },
-        '/b/users/something': { delete: serializedDeleteFuntion },
-        '/b/x/test': { get: { status: 200 } },
-        '/b/x/users/something': { delete: serializedDeleteFuntion },
-        '/b/y/test': { get: { status: 200 } },
-        '/b/y/users/something': { delete: serializedDeleteFuntion },
-        '/b/y/z/test': { get: { status: 200 } },
-        '/b/y/z/users/something': { delete: serializedDeleteFuntion },
-        '/c/mjs/': { get: { status: 200 } },
-        '/c/mts/': { get: { status: 200 } },
-        '/c/test': { get: { status: 200 } },
-        '/c/users/something': { delete: serializedDeleteFuntion },
-        '/c/x/test': { get: { status: 200 } },
-        '/c/x/users/something': { delete: serializedDeleteFuntion },
-        '/c/x/z/test': { get: { status: 200 } },
-        '/c/x/z/users/something': { delete: serializedDeleteFuntion },
-      });
+          '/c/mjs/': { get: { status: 200 } },
+        });
+      } else {
+        assert.deepStrictEqual(routerConfig, {
+          '/a/test': { get: { status: 200 } },
+          '/a/users/something': { delete: serializedDeleteFuntion },
+          '/a/y/test': { get: { status: 200 } },
+          '/a/y/users/something': { delete: serializedDeleteFuntion },
+          '/a/y/z/test': { get: { status: 200 } },
+          '/a/y/z/users/something': { delete: serializedDeleteFuntion },
+          '/b/json-b-test': {
+            get: {
+              status: 200,
+            },
+          },
+          '/b/json-b-test/users/something': {
+            delete: {
+              body: '<!DOCTYPE html><html><head><title>Nope</title></head><body><h1>405 Method not allowed</h1></body><html>',
+              headers: {
+                'Content-Type': 'text/html',
+              },
+              status: 405,
+            },
+          },
+          '/b/test': { get: { status: 200 } },
+          '/b/users/something': { delete: serializedDeleteFuntion },
+          '/b/x/test': { get: { status: 200 } },
+          '/b/x/users/something': { delete: serializedDeleteFuntion },
+          '/b/y/test': { get: { status: 200 } },
+          '/b/y/users/something': { delete: serializedDeleteFuntion },
+          '/b/y/z/test': { get: { status: 200 } },
+          '/b/y/z/users/something': { delete: serializedDeleteFuntion },
+          '/c/mjs/': { get: { status: 200 } },
+          '/c/mts/': { get: { status: 200 } },
+          '/c/test': { get: { status: 200 } },
+          '/c/users/something': { delete: serializedDeleteFuntion },
+          '/c/x/test': { get: { status: 200 } },
+          '/c/x/users/something': { delete: serializedDeleteFuntion },
+          '/c/x/z/test': { get: { status: 200 } },
+          '/c/x/z/users/something': { delete: serializedDeleteFuntion },
+        });
+      }
     });
   });
 }).catch(console.error);

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -61,7 +61,7 @@ describe(relative(process.cwd(), __filename), async () => {
     await assert.rejects(main(['-p', 'a1']), /Error: invalid port a1/);
   });
 
-  await it('can load routes on config', async () => {
+  await it('can load routes from folder', async () => {
     const routes = join(__dirname, 'fixtures', 'load-from-dir');
     const serializedDeleteFuntion =
       "delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }";
@@ -98,6 +98,7 @@ describe(relative(process.cwd(), __filename), async () => {
         '/b/y/users/something': { delete: serializedDeleteFuntion },
         '/b/y/z/test': { get: { status: 200 } },
         '/b/y/z/users/something': { delete: serializedDeleteFuntion },
+        '/c/mts/': { get: { status: 200 } },
         '/c/test': { get: { status: 200 } },
         '/c/users/something': { delete: serializedDeleteFuntion },
         '/c/x/test': { get: { status: 200 } },
@@ -139,6 +140,7 @@ describe(relative(process.cwd(), __filename), async () => {
         '/b/y/users/something': { delete: serializedDeleteFuntion },
         '/b/y/z/test': { get: { status: 200 } },
         '/b/y/z/users/something': { delete: serializedDeleteFuntion },
+        '/c/mts/': { get: { status: 200 } },
         '/c/test': { get: { status: 200 } },
         '/c/users/something': { delete: serializedDeleteFuntion },
         '/c/x/test': { get: { status: 200 } },
@@ -180,6 +182,7 @@ describe(relative(process.cwd(), __filename), async () => {
         '/b/y/users/something': { delete: serializedDeleteFuntion },
         '/b/y/z/test': { get: { status: 200 } },
         '/b/y/z/users/something': { delete: serializedDeleteFuntion },
+        '/c/mts/': { get: { status: 200 } },
         '/c/test': { get: { status: 200 } },
         '/c/users/something': { delete: serializedDeleteFuntion },
         '/c/x/test': { get: { status: 200 } },
@@ -224,6 +227,55 @@ describe(relative(process.cwd(), __filename), async () => {
           urlRegex: /^\/some\/other\/path(\?.*)?$/g,
           post: { status: 101 },
         },
+      });
+    });
+  });
+
+  await it('can load ts routes from folder', async () => {
+    const routes = join(__dirname, '../../test/fixtures/load-from-dir');
+    const serializedDeleteFuntion =
+      "delete(req     , res     ) {\n      return res.writeHead(301, 'google.ca');\n    }";
+
+    await start(['-q', '-r', routes], (server) => {
+      const routerConfig = JSON.parse(formatRoutesForPrinting(server.router.routes)) as unknown;
+
+      assert.deepStrictEqual(routerConfig, {
+        '/a/test': { get: { status: 200 } },
+        '/a/users/something': { delete: serializedDeleteFuntion },
+        '/a/y/test': { get: { status: 200 } },
+        '/a/y/users/something': { delete: serializedDeleteFuntion },
+        '/a/y/z/test': { get: { status: 200 } },
+        '/a/y/z/users/something': { delete: serializedDeleteFuntion },
+        '/b/json-b-test': {
+          get: {
+            status: 200,
+          },
+        },
+        '/b/json-b-test/users/something': {
+          delete: {
+            body: '<!DOCTYPE html><html><head><title>Nope</title></head><body><h1>405 Method not allowed</h1></body><html>',
+            headers: {
+              'Content-Type': 'text/html',
+            },
+            status: 405,
+          },
+        },
+        '/b/test': { get: { status: 200 } },
+        '/b/users/something': { delete: serializedDeleteFuntion },
+        '/b/x/test': { get: { status: 200 } },
+        '/b/x/users/something': { delete: serializedDeleteFuntion },
+        '/b/y/test': { get: { status: 200 } },
+        '/b/y/users/something': { delete: serializedDeleteFuntion },
+        '/b/y/z/test': { get: { status: 200 } },
+        '/b/y/z/users/something': { delete: serializedDeleteFuntion },
+        '/c/mjs/': { get: { status: 200 } },
+        '/c/mts/': { get: { status: 200 } },
+        '/c/test': { get: { status: 200 } },
+        '/c/users/something': { delete: serializedDeleteFuntion },
+        '/c/x/test': { get: { status: 200 } },
+        '/c/x/users/something': { delete: serializedDeleteFuntion },
+        '/c/x/z/test': { get: { status: 200 } },
+        '/c/x/z/users/something': { delete: serializedDeleteFuntion },
       });
     });
   });

--- a/test/fixtures/load-from-dir/c/c-mjs.routes.mjs
+++ b/test/fixtures/load-from-dir/c/c-mjs.routes.mjs
@@ -1,0 +1,5 @@
+export const routes = {
+  'mjs/': {
+    get: { status: 200 },
+  },
+};

--- a/test/fixtures/load-from-dir/c/c-mts.routes.mts
+++ b/test/fixtures/load-from-dir/c/c-mts.routes.mts
@@ -1,6 +1,6 @@
 export const data = [];
 
-export const routes = {
+export const routes: Record<string, object> = {
   'mts/': {
     get: { status: 200 },
   },

--- a/test/fixtures/load-from-dir/c/c-mts.routes.mts
+++ b/test/fixtures/load-from-dir/c/c-mts.routes.mts
@@ -1,0 +1,7 @@
+export const data = [];
+
+export const routes = {
+  'mts/': {
+    get: { status: 200 },
+  },
+};

--- a/test/fixtures/ts-support.ts
+++ b/test/fixtures/ts-support.ts
@@ -1,0 +1,2 @@
+// this file just exists for tests to check typescript support via require (node 22+)
+export const routes: Record<string, string> = {};

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -53,7 +53,7 @@ describe(relative(process.cwd(), __filename), async () => {
     await proxy.listen();
     context.after(() => proxy.close({ closeConnections: true }));
 
-    assert.deepStrictEqual(routeConfig['proxied-server(?<path>.*)'] as PathConfig, {
+    assert.deepStrictEqual(routeConfig['proxied-server(?<path>.*)'], {
       proxy: 'https://www.google.com:path',
       proxyOptions: {
         headers: {
@@ -189,8 +189,7 @@ describe(relative(process.cwd(), __filename), async () => {
   await it('can read filesystem for routing', async () => {
     await moxy.addRoutesFromFolder(join(__dirname, 'fixtures', 'load-from-dir'));
 
-    const serializedDeleteFuntion =
-      "delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }";
+    const serializedDeleteFuntion = "delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }";
 
     await request.get('/_moxy/router').expect(({ status, body }) => {
       assert.strictEqual(status, 200);
@@ -399,24 +398,22 @@ describe(relative(process.cwd(), __filename), async () => {
       },
     });
 
-    await request
-      .get('/bad-proxy/proxier')
-      .expect<{ status: number; message: NetError }>(({ status, body, headers }) => {
-        assert.deepStrictEqual(
-          { status, body },
-          {
+    await request.get('/bad-proxy/proxier').expect<{ status: number; message: NetError }>(({ status, body, headers }) => {
+      assert.deepStrictEqual(
+        { status, body },
+        {
+          status: 502,
+          body: {
             status: 502,
-            body: {
-              status: 502,
-              message: {
-                ...body.message,
-                code: 'ECONNREFUSED',
-              },
+            message: {
+              ...body.message,
+              code: 'ECONNREFUSED',
             },
           },
-        );
-        assert.strictEqual(headers['x-moxy-error'], 'proxy error');
-      });
+        },
+      );
+      assert.strictEqual(headers['x-moxy-error'], 'proxy error');
+    });
 
     let timer: NodeJS.Timeout | undefined;
     proxyTarget.on('/slow', {

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -223,6 +223,7 @@ describe(relative(process.cwd(), __filename), async () => {
         '/b/y/users/something': { delete: serializedDeleteFuntion },
         '/b/y/z/test': { get: { status: 200 } },
         '/b/y/z/users/something': { delete: serializedDeleteFuntion },
+        '/c/mts/': { get: { status: 200 } },
         '/c/test': { get: { status: 200 } },
         '/c/users/something': { delete: serializedDeleteFuntion },
         '/c/x/test': { get: { status: 200 } },

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
-import { join, relative } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import { after, afterEach, before, describe, it } from 'node:test';
 import { routeConfig } from '../examples/example-routing/example.routes';
-import { MoxyServer, PathConfig, RequestHandler } from '../src';
+import { formatRoutesForPrinting, MoxyServer, PathConfig, RequestHandler } from '../src';
 import { getRequest, TestRequest } from './shared/test-util';
 
 type NetError = {
@@ -730,5 +730,53 @@ describe(relative(process.cwd(), __filename), async () => {
     await request.get('/modify-me').expect(({ status, body }) => {
       assert.deepStrictEqual({ status, body }, { status: 200, body: { message: 'configured' } });
     });
+  });
+
+  await it('resolves folder paths', async () => {
+    const routesFolder = join(__dirname, 'fixtures/load-from-dir/a/y');
+    const paths = {
+      routesFolder,
+      relative: relative(process.cwd(), routesFolder),
+      dotRelative: './' + relative(process.cwd(), routesFolder),
+      abs: resolve('./' + relative(process.cwd(), routesFolder)),
+    };
+    assert.deepStrictEqual(paths, {
+      routesFolder: process.cwd() + '/dist/test/fixtures/load-from-dir/a/y',
+      relative: 'dist/test/fixtures/load-from-dir/a/y',
+      dotRelative: './dist/test/fixtures/load-from-dir/a/y',
+      abs: process.cwd() + '/dist/test/fixtures/load-from-dir/a/y',
+    });
+
+    const expectedRoutes = {
+      'test': { get: { status: 200 } },
+      'users/something': {
+        delete: `delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }`,
+      },
+      '/z/test': { get: { status: 200 } },
+      '/z/users/something': {
+        delete: `delete(req, res) {\n            return res.writeHead(301, 'google.ca');\n        }`,
+      },
+    };
+
+    moxy.resetRoutes();
+    await moxy.addRoutesFromFolder(paths.routesFolder);
+    assert.deepStrictEqual(JSON.parse(formatRoutesForPrinting(moxy.router.routes)), expectedRoutes);
+
+    moxy.resetRoutes();
+    await moxy.addRoutesFromFolder(paths.relative);
+    assert.deepStrictEqual(JSON.parse(formatRoutesForPrinting(moxy.router.routes)), expectedRoutes);
+
+    moxy.resetRoutes();
+    await moxy.addRoutesFromFolder(paths.dotRelative);
+    assert.deepStrictEqual(JSON.parse(formatRoutesForPrinting(moxy.router.routes)), expectedRoutes);
+
+    moxy.resetRoutes();
+    await moxy.addRoutesFromFolder(paths.abs);
+    assert.deepStrictEqual(JSON.parse(formatRoutesForPrinting(moxy.router.routes)), expectedRoutes);
+  });
+
+  await it("shows errors when loading files that don't exist", async () => {
+    await assert.rejects(() => moxy.addRoutesFromFolder('../not-exists/'));
+    await assert.rejects(() => moxy.loadConfigFromFile('../not-exists/file.js', '../not-exists'));
   });
 }).catch(console.error);


### PR DESCRIPTION
allow routes files to additionally be mjs, mts, or ts.

BREAKING CHANGE: since this means routes folders will parse more routes, if someone was outputting js files next to ts, this could cause unexpected behaviour when loading from the folder, so this is a major.