### PR TITLE
feat/healthcheck

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -903,6 +903,7 @@ Returns the list of api methods:
 {
   "GET /router?once=false&serializeMethods=true": "show router",
   "GET /routes?once=false": "show router routes",
+  "GET /health": "Return 200 OK if healthy",
   // below are only available with '--allow-http-config'
   "POST /routes?once=false": "create route",
   "PUT /routes/:route": "create or update route",
@@ -911,6 +912,11 @@ Returns the list of api methods:
 }
 
 ```
+
+
+#### GET /\_moxy/health
+
+Returns 200 OK if healthy, without logging (added in 5.1.0).  
 
 
 #### GET /\_moxy/routes

--- a/src/server/moxy-server.ts
+++ b/src/server/moxy-server.ts
@@ -244,6 +244,10 @@ export class MoxyServer {
       options,
       /* eslint-disable-next-line @typescript-eslint/no-misused-promises */
       async (req: IncomingMessage, res: ServerResponse): Promise<unknown> => {
+        if (req.url === '/_moxy/health') {
+          return res.writeHead(200, 'OK', { 'content-type': 'text/plain' }).end('OK');
+        }
+
         this.#responses[(req as MoxyRequest).id] = res as MoxyResponse;
 
         try {

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -57,6 +57,24 @@ describe(relative(process.cwd(), __filename), async () => {
     });
   });
 
+  await it('GET /_moxy/health - responds to a healthcheck', async () => {
+    await request.get('/_moxy/health').expect(({ status, text, headers }) => {
+      assert.deepStrictEqual(
+        { status, text, headers },
+        {
+          status: 200,
+          text: 'OK',
+          headers: {
+            'content-type': 'text/plain',
+            'date': headers.date,
+            'connection': 'close',
+            'transfer-encoding': 'chunked',
+          },
+        },
+      );
+    });
+  });
+
   await it('GET /_moxy/routes - can list available routes', async () => {
     await request.get('/_moxy/routes').expect(({ status, body }) => {
       assert.deepStrictEqual({ status, body }, { status: 200, body: [] });


### PR DESCRIPTION
skips logging and request processing, simply returns 200 ok text immediately.